### PR TITLE
Bugfix for redis complaining "value is not an integer or out of range"

### DIFF
--- a/item.go
+++ b/item.go
@@ -7,7 +7,7 @@ import (
 type (
 	// Item :nodoc:
 	Item interface {
-		GetTTLFloat64() float64
+		GetTTLInt64() int64
 		GetKey() string
 		GetValue() interface{}
 	}
@@ -36,9 +36,9 @@ func NewItemWithCustomTTL(key string, value interface{}, customTTL time.Duration
 	}
 }
 
-// GetTTLFloat64 :nodoc:
-func (i *item) GetTTLFloat64() float64 {
-	return i.ttl.Seconds()
+// GetTTLInt64 :nodoc:
+func (i *item) GetTTLInt64() int64 {
+	return int64(i.ttl.Seconds())
 }
 
 // GetKey :nodoc:

--- a/keeper.go
+++ b/keeper.go
@@ -251,12 +251,12 @@ func (k *keeper) AcquireLock(key string) (*redsync.Mutex, error) {
 	return m, m.Lock()
 }
 
-func (k *keeper) decideCacheTTL(c Item) float64 {
-	if c.GetTTLFloat64() > 0 {
-		return c.GetTTLFloat64()
+func (k *keeper) decideCacheTTL(c Item) (ttl int64) {
+	if ttl = c.GetTTLInt64(); ttl > 0 {
+		return
 	}
 
-	return k.defaultTTL.Seconds()
+	return int64(k.defaultTTL.Seconds())
 }
 
 func (k *keeper) getCachedItem(key string) (value interface{}, err error) {

--- a/keeper_test.go
+++ b/keeper_test.go
@@ -160,11 +160,11 @@ func TestDecideCacheTTL(t *testing.T) {
 
 	// It should use keeper's default TTL when new cache item didn't specify the TTL
 	i := NewItem(testKey, nil)
-	assert.Equal(t, k.defaultTTL.Seconds(), k.decideCacheTTL(i))
+	assert.Equal(t, int64(k.defaultTTL.Seconds()), k.decideCacheTTL(i))
 
 	// It should use specified TTL when new cache item specify the TTL
 	i2 := NewItemWithCustomTTL(testKey, nil, 10*time.Second)
-	assert.Equal(t, i2.GetTTLFloat64(), k.decideCacheTTL(i))
+	assert.Equal(t, i2.GetTTLInt64(), k.decideCacheTTL(i))
 }
 
 func TestIncreaseCachedValueByOne(t *testing.T) {


### PR DESCRIPTION
The library throws error when storing with huge TTL. This caused by  redigo refusing float64 so needed to replace with int64 instead.