### PR TITLE
[WIP] feature: implement dynamic TTL

### DIFF
--- a/common.go
+++ b/common.go
@@ -47,7 +47,7 @@ func getOffset(page, limit int64) int64 {
 	return offset
 }
 
-func get(client redigo.Conn, key string, counterKey string) (value any, counter int, err error) {
+func get(client redigo.Conn, key string, cacheHitKey string) (value any, cacheHit int, err error) {
 	defer func() {
 		_ = client.Close()
 	}()
@@ -64,7 +64,7 @@ func get(client redigo.Conn, key string, counterKey string) (value any, counter 
 	if err != nil {
 		return nil, 0, err
 	}
-	err = client.Send("GET", counterKey)
+	err = client.Send("GET", cacheHitKey)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -79,12 +79,12 @@ func get(client redigo.Conn, key string, counterKey string) (value any, counter 
 	}
 
 	bt, _ := res[2].([]byte)
-	err = json.Unmarshal(bt, &counter)
+	err = json.Unmarshal(bt, &cacheHit)
 	if err != nil {
 		return res[1], 0, nil
 	}
 
-	return res[1], counter, nil
+	return res[1], cacheHit, nil
 }
 
 func getHashMember(client redigo.Conn, identifier, key string) (value any, err error) {

--- a/common.go
+++ b/common.go
@@ -117,6 +117,6 @@ func getHashMember(client redigo.Conn, identifier, key string) (value any, err e
 	return res[1], nil
 }
 
-func generateCounterKey(key string) string {
-	return fmt.Sprintf("%s:dynamic:ttl:counter", key)
+func generateCacheHitKey(key string) string {
+	return fmt.Sprintf("%s:cache:hit:counter", key)
 }

--- a/keeper.go
+++ b/keeper.go
@@ -53,7 +53,7 @@ type (
 		SetLockTries(int)
 		SetWaitTime(time.Duration)
 		SetDisableCaching(bool)
-		SetDisableDynamicTTL(bool)
+		SetEnableDynamicTTL(bool)
 		SetThresholdDynamicTTL(int)
 
 		CheckKeyExist(string) (bool, error)
@@ -87,7 +87,7 @@ type (
 		waitTime       time.Duration
 		disableCaching bool
 
-		disableDynamicTTL   bool
+		enableDynamicTTL    bool
 		thresholdDynamicTTL int
 
 		lockConnPool *redigo.Pool
@@ -105,7 +105,7 @@ func NewKeeper() Keeper {
 		lockTries:           defaultLockTries,
 		waitTime:            defaultWaitTime,
 		disableCaching:      false,
-		disableDynamicTTL:   false,
+		enableDynamicTTL:    false,
 		thresholdDynamicTTL: defaultThresholdDynamicTTL,
 	}
 }
@@ -150,8 +150,8 @@ func (k *keeper) SetDisableCaching(b bool) {
 }
 
 // SetDisableDynamicTTL :nodoc:
-func (k *keeper) SetDisableDynamicTTL(b bool) {
-	k.disableDynamicTTL = b
+func (k *keeper) SetEnableDynamicTTL(b bool) {
+	k.enableDynamicTTL = b
 }
 
 // SetThresholdDynamicTTL :nodoc:
@@ -177,7 +177,7 @@ func (k *keeper) Get(key string) (cachedItem any, err error) {
 		return nil, nil
 	}
 
-	if k.disableDynamicTTL {
+	if !k.enableDynamicTTL {
 		return
 	}
 
@@ -445,7 +445,7 @@ func (k *keeper) StoreMultiWithoutBlocking(items []Item) error {
 			return err
 		}
 
-		if k.disableDynamicTTL {
+		if !k.enableDynamicTTL {
 			continue
 		}
 
@@ -484,7 +484,7 @@ func (k *keeper) StoreMultiPersist(items []Item) error {
 			return err
 		}
 
-		if k.disableDynamicTTL {
+		if !k.enableDynamicTTL {
 			continue
 		}
 

--- a/keeper.go
+++ b/keeper.go
@@ -311,22 +311,7 @@ func (k *keeper) StoreWithoutBlocking(c Item) error {
 		_ = client.Close()
 	}()
 
-	err := client.Send("MULTI")
-	if err != nil {
-		return err
-	}
-	err = client.Send("SETEX", c.GetKey(), k.decideCacheTTL(c), c.GetValue())
-	if err != nil {
-		return err
-	}
-	if !k.disableDynamicTTL {
-		err = client.Send("SET", generateCacheHitKey(c.GetKey()), 0)
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err = redigo.Values(client.Do("EXEC"))
+	_, err := client.Do("SETEX", c.GetKey(), k.decideCacheTTL(c), c.GetValue())
 	return err
 }
 

--- a/keeper.go
+++ b/keeper.go
@@ -165,8 +165,8 @@ func (k *keeper) Get(key string) (cachedItem any, err error) {
 		return
 	}
 
-	counterKey := generateCacheHitKey(key)
-	cachedItem, counter, err := get(k.connPool.Get(), key, counterKey)
+	cacheHitKey := generateCacheHitKey(key)
+	cachedItem, cacheHit, err := get(k.connPool.Get(), key, cacheHitKey)
 	switch err {
 	case nil, ErrKeyNotExist, redigo.ErrNil:
 	default:
@@ -181,7 +181,7 @@ func (k *keeper) Get(key string) (cachedItem any, err error) {
 		return
 	}
 
-	err = k.incrementTTL(key, counterKey, counter)
+	err = k.incrementTTL(key, cacheHitKey, cacheHit)
 	if err != nil {
 		return nil, err
 	}
@@ -941,9 +941,9 @@ func (k *keeper) isLocked(key string) bool {
 	return true
 }
 
-func (k *keeper) incrementTTL(key, counterKey string, counter int) (err error) {
-	if counter < k.thresholdDynamicTTL {
-		return k.IncreaseCachedValueByOne(counterKey)
+func (k *keeper) incrementTTL(key, cacheHitKey string, cacheHit int) (err error) {
+	if cacheHit < k.thresholdDynamicTTL {
+		return k.IncreaseCachedValueByOne(cacheHitKey)
 	}
 
 	client := k.connPool.Get()

--- a/keeper.go
+++ b/keeper.go
@@ -165,7 +165,7 @@ func (k *keeper) Get(key string) (cachedItem any, err error) {
 		return
 	}
 
-	counterKey := generateCounterKey(key)
+	counterKey := generateCacheHitKey(key)
 	cachedItem, counter, err := get(k.connPool.Get(), key, counterKey)
 	switch err {
 	case nil, ErrKeyNotExist, redigo.ErrNil:
@@ -320,7 +320,7 @@ func (k *keeper) StoreWithoutBlocking(c Item) error {
 		return err
 	}
 	if !k.disableDynamicTTL {
-		err = client.Send("SET", generateCounterKey(c.GetKey()), 0)
+		err = client.Send("SET", generateCacheHitKey(c.GetKey()), 0)
 		if err != nil {
 			return err
 		}
@@ -432,7 +432,7 @@ func (k *keeper) DeleteByKeys(keys []string) error {
 
 	var redisKeys []any
 	for _, key := range keys {
-		redisKeys = append(redisKeys, key, generateCounterKey(key))
+		redisKeys = append(redisKeys, key, generateCacheHitKey(key))
 	}
 
 	_, err := client.Do("DEL", redisKeys...)
@@ -464,7 +464,7 @@ func (k *keeper) StoreMultiWithoutBlocking(items []Item) error {
 			continue
 		}
 
-		err = client.Send("SET", generateCounterKey(item.GetKey()), 0)
+		err = client.Send("SET", generateCacheHitKey(item.GetKey()), 0)
 		if err != nil {
 			return err
 		}
@@ -503,7 +503,7 @@ func (k *keeper) StoreMultiPersist(items []Item) error {
 			continue
 		}
 
-		err = client.Send("SET", generateCounterKey(item.GetKey()), 0)
+		err = client.Send("SET", generateCacheHitKey(item.GetKey()), 0)
 		if err != nil {
 			return err
 		}

--- a/keeper_test.go
+++ b/keeper_test.go
@@ -86,6 +86,7 @@ func TestGet(t *testing.T) {
 	k.SetConnectionPool(r)
 	k.SetLockConnectionPool(r)
 	k.SetWaitTime(1 * time.Second) // override wait time to 1 second
+	k.SetEnableDynamicTTL(true)
 
 	testKey := "test-key"
 
@@ -122,8 +123,8 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("Disable Dynamic TTL", func(t *testing.T) {
-		k.SetDisableDynamicTTL(true)
-		defer k.SetDisableDynamicTTL(false)
+		k.SetEnableDynamicTTL(false)
+		defer k.SetEnableDynamicTTL(true)
 
 		testKey := "test-key-disable-ttl"
 

--- a/keeper_test.go
+++ b/keeper_test.go
@@ -329,31 +329,6 @@ func TestStore(t *testing.T) {
 		assert.False(t, m.Exists(testKey))
 	})
 
-	t.Run("Disable Dynamic TTL", func(t *testing.T) {
-		k.SetDisableDynamicTTL(true)
-		defer k.SetDisableDynamicTTL(false)
-
-		testKey := "store-new-key-disable-dynamic-ttl"
-		assert.False(t, m.Exists(testKey))
-
-		mu, err := k.AcquireLock(testKey)
-		assert.NoError(t, err)
-
-		marshalCache, err := json.Marshal(val)
-		assert.NoError(t, err)
-		cacheItem := NewItem(testKey, marshalCache)
-
-		err = k.Store(mu, cacheItem)
-		require.NoError(t, err)
-		assert.True(t, m.Exists(testKey))
-
-		cachedValue, err := m.Get(testKey)
-		require.NoError(t, err)
-		assert.Equal(t, string(valByte), cachedValue)
-
-		assert.False(t, m.Exists(generateCacheHitKey(testKey)))
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		testKey := "store-new-key"
 		assert.False(t, m.Exists(testKey))
@@ -372,12 +347,6 @@ func TestStore(t *testing.T) {
 		cachedValue, err := m.Get(testKey)
 		require.NoError(t, err)
 		assert.Equal(t, string(valByte), cachedValue)
-
-		assert.True(t, m.Exists(generateCacheHitKey(testKey)))
-
-		cachedValue, err = m.Get(generateCacheHitKey(testKey))
-		require.NoError(t, err)
-		assert.Equal(t, "0", cachedValue)
 	})
 }
 
@@ -424,29 +393,6 @@ func TestStoreWithoutBlocking(t *testing.T) {
 		assert.False(t, m.Exists(testKey))
 	})
 
-	t.Run("Disable Dynamic TTL", func(t *testing.T) {
-		k.SetDisableDynamicTTL(true)
-		defer k.SetDisableDynamicTTL(false)
-
-		testKey := "store-new-key-disable-dynamic-ttl"
-
-		assert.False(t, m.Exists(testKey))
-
-		marshalCache, err := json.Marshal(val)
-		assert.NoError(t, err)
-		cacheItem := NewItem(testKey, marshalCache)
-
-		err = k.StoreWithoutBlocking(cacheItem)
-		require.NoError(t, err)
-		assert.True(t, m.Exists(testKey))
-
-		cachedValue, err := m.Get(testKey)
-		require.NoError(t, err)
-		assert.Equal(t, string(valByte), cachedValue)
-
-		assert.False(t, m.Exists(generateCacheHitKey(testKey)))
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		assert.False(t, m.Exists(testKey))
 
@@ -461,12 +407,6 @@ func TestStoreWithoutBlocking(t *testing.T) {
 		cachedValue, err := m.Get(testKey)
 		require.NoError(t, err)
 		assert.Equal(t, string(valByte), cachedValue)
-
-		assert.True(t, m.Exists(generateCacheHitKey(testKey)))
-
-		cachedValue, err = m.Get(generateCacheHitKey(testKey))
-		require.NoError(t, err)
-		assert.Equal(t, "0", cachedValue)
 	})
 }
 

--- a/keeper_test.go
+++ b/keeper_test.go
@@ -103,7 +103,7 @@ func TestGet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, result)
 
-		assert.False(t, m.Exists(generateCounterKey(testKey)))
+		assert.False(t, m.Exists(generateCacheHitKey(testKey)))
 	})
 
 	t.Run("Exist", func(t *testing.T) {
@@ -115,8 +115,8 @@ func TestGet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, result, val)
 
-		assert.True(t, m.Exists(generateCounterKey(testKey)))
-		counter, err := m.Get(generateCounterKey(testKey))
+		assert.True(t, m.Exists(generateCacheHitKey(testKey)))
+		counter, err := m.Get(generateCacheHitKey(testKey))
 		assert.NoError(t, err)
 		assert.Equal(t, "1", counter)
 	})
@@ -130,7 +130,7 @@ func TestGet(t *testing.T) {
 		val := "something-something-here"
 		_ = m.Set(testKey, val)
 
-		assert.False(t, m.Exists(generateCounterKey(testKey)))
+		assert.False(t, m.Exists(generateCacheHitKey(testKey)))
 
 		assert.True(t, m.Exists(testKey))
 		result, err := k.Get(testKey)
@@ -140,7 +140,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("Increase ttl", func(t *testing.T) {
 		val := "something-something-here"
-		testKeyCounter := generateCounterKey(testKey)
+		testKeyCounter := generateCacheHitKey(testKey)
 		valCounter := "10"
 
 		testTTL := 10 * time.Second
@@ -351,7 +351,7 @@ func TestStore(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(valByte), cachedValue)
 
-		assert.False(t, m.Exists(generateCounterKey(testKey)))
+		assert.False(t, m.Exists(generateCacheHitKey(testKey)))
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -373,9 +373,9 @@ func TestStore(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(valByte), cachedValue)
 
-		assert.True(t, m.Exists(generateCounterKey(testKey)))
+		assert.True(t, m.Exists(generateCacheHitKey(testKey)))
 
-		cachedValue, err = m.Get(generateCounterKey(testKey))
+		cachedValue, err = m.Get(generateCacheHitKey(testKey))
 		require.NoError(t, err)
 		assert.Equal(t, "0", cachedValue)
 	})
@@ -444,7 +444,7 @@ func TestStoreWithoutBlocking(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(valByte), cachedValue)
 
-		assert.False(t, m.Exists(generateCounterKey(testKey)))
+		assert.False(t, m.Exists(generateCacheHitKey(testKey)))
 	})
 
 	t.Run("Success", func(t *testing.T) {
@@ -462,9 +462,9 @@ func TestStoreWithoutBlocking(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(valByte), cachedValue)
 
-		assert.True(t, m.Exists(generateCounterKey(testKey)))
+		assert.True(t, m.Exists(generateCacheHitKey(testKey)))
 
-		cachedValue, err = m.Get(generateCounterKey(testKey))
+		cachedValue, err = m.Get(generateCacheHitKey(testKey))
 		require.NoError(t, err)
 		assert.Equal(t, "0", cachedValue)
 	})

--- a/keeper_test.go
+++ b/keeper_test.go
@@ -116,9 +116,9 @@ func TestGet(t *testing.T) {
 		assert.EqualValues(t, result, val)
 
 		assert.True(t, m.Exists(generateCacheHitKey(testKey)))
-		counter, err := m.Get(generateCacheHitKey(testKey))
+		cacheHit, err := m.Get(generateCacheHitKey(testKey))
 		assert.NoError(t, err)
-		assert.Equal(t, "1", counter)
+		assert.Equal(t, "1", cacheHit)
 	})
 
 	t.Run("Disable Dynamic TTL", func(t *testing.T) {
@@ -140,22 +140,22 @@ func TestGet(t *testing.T) {
 
 	t.Run("Increase ttl", func(t *testing.T) {
 		val := "something-something-here"
-		testKeyCounter := generateCacheHitKey(testKey)
-		valCounter := "10"
+		testKeyCacheHit := generateCacheHitKey(testKey)
+		valCacheHit := "10"
 
 		testTTL := 10 * time.Second
 
 		_ = m.Set(testKey, val)
 		m.SetTTL(testKey, testTTL)
 
-		_ = m.Set(testKeyCounter, valCounter)
+		_ = m.Set(testKeyCacheHit, valCacheHit)
 
 		assert.True(t, m.Exists(testKey))
-		assert.True(t, m.Exists(testKeyCounter))
+		assert.True(t, m.Exists(testKeyCacheHit))
 
-		validateCounter, err := m.Get(testKeyCounter)
+		validateCacheHit, err := m.Get(testKeyCacheHit)
 		assert.NoError(t, err)
-		assert.Equal(t, valCounter, validateCounter)
+		assert.Equal(t, valCacheHit, validateCacheHit)
 
 		result, err := k.Get(testKey)
 		assert.NoError(t, err)

--- a/keeper_with_failover.go
+++ b/keeper_with_failover.go
@@ -138,22 +138,7 @@ func (k *KeeperWithFailover) StoreFailover(c Item) error {
 		_ = client.Close()
 	}()
 
-	err := client.Send("MULTI")
-	if err != nil {
-		return err
-	}
-	err = client.Send("SETEX", c.GetKey(), k.failoverTTL.Seconds(), c.GetValue())
-	if err != nil {
-		return err
-	}
-	if !k.disableDynamicTTL {
-		err = client.Send("SET", generateCacheHitKey(c.GetKey()), 0)
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err = redigo.Values(client.Do("EXEC"))
+	_, err := client.Do("SETEX", c.GetKey(), k.decideCacheTTL(c), c.GetValue())
 	return err
 }
 

--- a/keeper_with_failover.go
+++ b/keeper_with_failover.go
@@ -115,7 +115,7 @@ func (k *KeeperWithFailover) GetFailover(key string) (cachedItem any, err error)
 		return nil, nil
 	}
 
-	if k.disableDynamicTTL {
+	if !k.enableDynamicTTL {
 		return
 	}
 

--- a/keeper_with_failover.go
+++ b/keeper_with_failover.go
@@ -103,7 +103,7 @@ func (k *KeeperWithFailover) GetFailover(key string) (cachedItem any, err error)
 		return
 	}
 
-	counterKey := generateCounterKey(key)
+	counterKey := generateCacheHitKey(key)
 	cachedItem, counter, err := get(k.failoverConnPool.Get(), key, counterKey)
 	switch err {
 	case nil, ErrKeyNotExist, redigo.ErrNil:
@@ -147,7 +147,7 @@ func (k *KeeperWithFailover) StoreFailover(c Item) error {
 		return err
 	}
 	if !k.disableDynamicTTL {
-		err = client.Send("SET", generateCounterKey(c.GetKey()), 0)
+		err = client.Send("SET", generateCacheHitKey(c.GetKey()), 0)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ func (k *KeeperWithFailover) DeleteByKeys(keys []string) error {
 	}()
 	var redisKeys []any
 	for _, key := range keys {
-		redisKeys = append(redisKeys, key, generateCounterKey(key))
+		redisKeys = append(redisKeys, key, generateCacheHitKey(key))
 	}
 
 	var errs *multierror.Error


### PR DESCRIPTION
Reduced requests to the database by increasing the TTL in Redis. Considering that the requests to our service are getting bigger, we want to minimize requests to the database by counting the number of requests and this will have an impact on the data storage period in Redis. The higher the request the longer the data will be in Redis.